### PR TITLE
Fix array syntax while querying with arrays (for ex. WHERE IN)

### DIFF
--- a/src/ClickHouseStatement.php
+++ b/src/ClickHouseStatement.php
@@ -324,7 +324,7 @@ class ClickHouseStatement implements Statement
                     }, $values);
                 }
 
-                return '[' . implode(', ', $values) . ']';
+                return '(' . implode(', ', $values) . ')';
             }
         }
 


### PR DESCRIPTION
Fixes array parameters, for example:
```
$qb->andWhere('my_field', ':values')->setParameter('values', [10, 11, 12]);
```
Before fix there was wrong syntax: `WHERE my_field IN [10, 11, 12]` instead of `WHERE my_field IN (10, 11, 12)`.

So `WHERE IN` was not usable at all.

BTW there is still an issue: third (optional) argument of `setParameter` is not working properly.
Adding new type to doctrine config does not make the lib build a proper query.
`$this->types` in `ClickhouseStatement` tells that the type of field used in `WHERE IN` is `2` which is the value of `Doctrine\DBAL\ParameterType::STRING`. I couldn't figure out where did it get that `2` from (Though `array(uint32)` was propagated).
As a result `array to string conversion` is being thrown.
So passing 3rd parameter to `setParameter` still does not work, I did not fix that because I couldn't imagine how should it be properly handled in `ClickhouseStatement`. 

BTW everything mentioned above affects `friendsofdoctrine/dbal-clickhouse` as well, I just don't see any sense to fix that as it is abandoned.